### PR TITLE
Vjezba 8, ispravke gresaka

### DIFF
--- a/lukav11102_21/vjezba8/my_ram_memory.vhdl
+++ b/lukav11102_21/vjezba8/my_ram_memory.vhdl
@@ -5,7 +5,7 @@ use ieee.numeric_std.all;
 
 entity my_ram_memory is
     generic(
-        ADDR_SIZE : integer := 4;
+        ADDR_SIZE : integer := 7;
         WORD_SIZE : integer := 8
     );
     port(
@@ -35,5 +35,5 @@ begin
     end process;
 end my_ram_memory_beh;
 
--- Posto je u tekstu zadatka data velicina RAM memorije od 128b, mozemo uzeti da je velicina memorijske rijeci 8b sto znaci da cemo onda imati 16 
--- ukupnih memorijskih lokacija, pa su nam potrebne adrese od 4b da bi ove lokacije adresirali.
+-- Posto je u tekstu zadatka data velicina RAM memorije od 128B, mozemo uzeti da je velicina memorijske rijeci 1B sto znaci da cemo onda imati 128 
+-- ukupnih memorijskih lokacija, pa su nam potrebne adrese od 7b da bi ove lokacije adresirali.

--- a/lukav11102_21/vjezba8/my_ram_memory_tb.vhdl
+++ b/lukav11102_21/vjezba8/my_ram_memory_tb.vhdl
@@ -5,7 +5,7 @@ use ieee.numeric_std.all;
 
 entity my_ram_memory_tb is
     generic(
-            TB_ADDR_SIZE : integer := 4;
+            TB_ADDR_SIZE : integer := 7;
             TB_WORD_SIZE : integer := 8
     );
 end my_ram_memory_tb;
@@ -14,7 +14,7 @@ architecture my_ram_memory_tb_beh of my_ram_memory_tb is
 
     component my_ram_memory is
         generic(
-            ADDR_SIZE : integer := 4;
+            ADDR_SIZE : integer := 7;
             WORD_SIZE : integer := 8
         );
         port(
@@ -37,7 +37,7 @@ begin
         wait for 10 ns;
         for i in 0 to 2**TB_ADDR_SIZE-1 loop
             addr <= std_logic_vector(to_unsigned(i, addr'length));
-            d_in <= std_logic_vector(to_unsigned(i**2, d_in'length));
+            d_in <= std_logic_vector(to_unsigned(i, d_in'length));
             clock <= '1';
             wait for 10 ns;
             clock <= '0';
@@ -49,7 +49,7 @@ begin
             addr <= std_logic_vector(to_unsigned(i, addr'length));
             clock <= '1';
             wait for 10 ns;
-            assert(i**2 = to_integer(unsigned(d_out))) report "Failed memory location, i = " & integer'image(i) severity error;
+            assert(i = to_integer(unsigned(d_out))) report "Failed memory location, i = " & integer'image(i) severity error;
             clock <= '0';
             wait for 10 ns;
         end loop;

--- a/lukav11102_21/vjezba8/work-obj93.cf
+++ b/lukav11102_21/vjezba8/work-obj93.cf
@@ -1,0 +1,7 @@
+v 4
+file . "my_ram_memory.vhdl" "d4c4f4734b02ba64e716319b9a13034a1f00dc05" "20230429100535.561":
+  entity my_ram_memory at 1( 0) + 0 on 47;
+  architecture my_ram_memory_beh of my_ram_memory at 19( 457) + 0 on 48;
+file . "my_ram_memory_tb.vhdl" "2eb3fb4e628aff452a8d662a137af1bb0b1a67c7" "20230429100535.562":
+  entity my_ram_memory_tb at 1( 0) + 0 on 49;
+  architecture my_ram_memory_tb_beh of my_ram_memory_tb at 13( 234) + 0 on 50;


### PR DESCRIPTION
- Uocene su greske u prethodno komitovanom labu, implementirano je da je memorija 128 bita, a ne 128 bajta kao sto treba
- U ovom komitu memorija je prosirena i greske su popravljene